### PR TITLE
Feature: Pull Request Merge

### DIFF
--- a/src/bitbucket/bb-pr-merge.sh
+++ b/src/bitbucket/bb-pr-merge.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+# Authentication and default settings
+source "$GITNAP/utils/auth.sh"
+source "$GITNAP/utils/endpoints.sh"
+source "$GITNAP/utils/settings.sh"
+source "$GITNAP/utils/format_pullrequest.sh"
+
+
+function create_bitbucket_pullrequest() {
+    local pr
+    local REPO
+    local WORKSPACE
+    local payload
+    local pr_endpoint
+    local endpoint
+    local response
+    
+    # Pull Request number
+    pr="$1"
+
+    # Verifica se o parâmetro foi fornecido
+    if [[ -z "$pr" ]]; then
+        echo "Pull Request number is required."
+        exit 1
+    fi
+        
+    # Name of repository
+    REPO="$2"
+    
+    # Verifica se o parâmetro foi fornecido
+    if [[ -z "$REPO" ]]; then
+        # Se não foi fornecido, utiliza o nome do diretório atual
+        REPO=$(basename "$PWD")
+    fi
+
+    # Repo owner
+    WORKSPACE="$3"
+    
+    # Verifica se o parâmetro foi fornecido
+    if [[ -z "$WORKSPACE" ]]; then
+        # Se não foi fornecido, utiliza o padrão definido em auth.sh
+        WORKSPACE="$DEF_WORKSPACE"
+    fi
+        
+    # Create the JSON payload for the repository
+    payload='{
+        "type": "merge",
+        "message": "merging pullrequests",
+        "close_source_branch": true,
+        "merge_strategy": "squash"
+    }'
+
+    # Construct URL endpoint
+    pr_endpoint="$(build_bb_endpoint "PR" "$WORKSPACE" "$REPO")"
+    endpoint="$endpoint/$pr/merge"
+    
+    # Create the repository using curl
+    response=$(curl -sSL -X POST "$endpoint" \
+        -H "$BITBUCKET_AUTH" \
+        -H 'Accept: application/json' \
+        -H 'Content-Type: application/json' \
+        -d "$payload" )
+
+    # Check if there are erros
+    echo "$response" #| jq -r '.iid // .message'
+}
+
+create_bitbucket_pullrequest "$1" "$2" "$3" 

--- a/src/github/gh-pr-merge.sh
+++ b/src/github/gh-pr-merge.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+# Authentication and default settings
+source "$GITNAP/utils/auth.sh"
+source "$GITNAP/utils/endpoints.sh"
+source "$GITNAP/utils/settings.sh"
+source "$GITNAP/utils/format_pullrequest.sh"
+
+
+function merge_github_pullrequest() {
+    local pr
+    local REPO
+    local OWNER
+    local pr_title
+    local pr_body
+    local source_branch
+    local target_branch
+    local payload
+    local endpoint
+    local response
+        
+    # Pull Request number
+    pr="$1"
+
+    # Verifica se o parâmetro foi fornecido
+    if [[ -z "$pr" ]]; then
+        echo "Pull Request number is required."
+        exit 1
+    fi
+        
+    # Name of repository
+    REPO="$2"
+    
+    # Verifica se o parâmetro foi fornecido
+    if [[ -z "$REPO" ]]; then
+        # Se não foi fornecido, utiliza o nome do diretório atual
+        REPO=$(basename "$PWD")
+    fi
+
+    # Repo owner
+    OWNER="$3"
+    
+    # Verifica se o parâmetro foi fornecido
+    if [[ -z "$OWNER" ]]; then
+        # Se não foi fornecido, utiliza o padrão definido em auth.sh
+        OWNER="$DEF_GH_OWNER"
+    fi
+        
+    # Create the JSON payload for the repository
+    payload='{"merge_method":"squash"}'
+
+    # Construct URL endpoint
+    pr_endpoint="$(build_gh_endpoint "PR" "$OWNER" "$REPO")"
+    endpoint="$pr_endpoint/$pr/merge"
+    
+    # Create the repository using curl
+    response=$(curl -sSL -X PUT "$endpoint" \
+        -H "Accept: application/vnd.github+json" \
+        -H "Authorization: Bearer $GITHUB_TOKEN" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        -d "$payload" )
+
+    # Check if there are erros
+    echo "$response" #| jq -r '.number // .message'
+}
+
+merge_github_pullrequest "$1" "$2" "$3"

--- a/src/gitlab/gl-pr-merge.sh
+++ b/src/gitlab/gl-pr-merge.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+# Authentication and default settings
+source "$GITNAP/utils/auth.sh"
+source "$GITNAP/utils/endpoints.sh"
+source "$GITNAP/utils/settings.sh"
+source "$GITNAP/utils/format_pullrequest.sh"
+
+
+function merge_gitlab_pullrequest() {
+    local pr
+    local REPO
+    local OWNER
+    local payload
+    local endpoint
+    local response
+        
+    # Pull Request number
+    pr="$1"
+
+    # Verifica se o parâmetro foi fornecido
+    if [[ -z "$pr" ]]; then
+        echo "Pull Request number is required."
+        exit 1
+    fi
+        
+    # Name of repository
+    REPO="$2"
+    
+    # Verifica se o parâmetro foi fornecido
+    if [[ -z "$REPO" ]]; then
+        # Se não foi fornecido, utiliza o nome do diretório atual
+        REPO=$(basename "$PWD")
+    fi
+
+    # Repo owner
+    OWNER="$3"
+    
+    # Verifica se o parâmetro foi fornecido
+    if [[ -z "$OWNER" ]]; then
+        # Se não foi fornecido, utiliza o padrão definido em auth.sh
+        OWNER="$DEF_GH_OWNER"
+    fi
+        
+    # Create the JSON payload for the repository
+    payload='{"merge_method":"squash"}'
+
+    # Construct the endpoint URL
+    pr_endpoint="$(build_gl_endpoint "PR" "$OWNER" "$REPO")"
+    endpoint="$pr_endpoint/$pr/merge"
+    
+    # Create the repository using curl
+    response=$(curl -sSL -X PUT "$endpoint" \
+        -H "Content-Type: application/json" \
+        -H "Authorization: Bearer $GITLAB_TOKEN" \
+        -d "$payload" )
+
+    # Check if there are erros
+    echo "$response" #| jq -r '.number // .message'
+}
+
+merge_gitlab_pullrequest "$1" "$2" "$3"


### PR DESCRIPTION
## Implements Pull Request Merge Functionality for Bitbucket, GitHub, and GitLab

This pull request introduces three new functions that enable users to merge existing pull requests directly within the tool, supporting Bitbucket, GitHub, and GitLab platforms.

* `bb-pr-merge.sh`: This function allows users to merge pull requests on Bitbucket. It takes necessary parameters such as the pull request ID and potentially merge commit message, and utilizes the Bitbucket API to perform the merge operation.
* `gh-pr-merge.sh`: This function provides similar functionality for merging pull requests on GitHub. It accepts parameters like the pull request number and optional commit message, and leverages the GitHub API to execute the merge.
* `gl-pr-merge.sh`: This function enables users to merge merge requests on GitLab. It takes parameters such as the merge request ID and optional commit message, and interacts with the GitLab API to trigger the merge action.

**How to use:**

+ <a href="https://github.com/rmottanet/gitnap/wiki"><img alt="Static Badge" src="https://img.shields.io/badge/gitnap-documentation?style=social&logo=github&logoSize=auto&label=docs&link=https%3A%2F%2Fgithub.com%2Frmottanet%2Fgitnap%2Fwiki"></a>
+ <a href="https://gitlab.com/rmottanet/gitnap.wiki.git"><img alt="Static Badge" src="https://img.shields.io/badge/gitnap-documentation?style=social&logo=gitlab&logoSize=auto&label=docs&link=https%3A%2F%2Fgitlab.com%2Frmottanet%2Fgitnap.wiki.git"></a>

**Feel free to review the code and provide any feedback.**