### PR TITLE
Feature: Implements Organization and Team Management Functionality for GitHub Actions

### DIFF
--- a/.github/workflows/gh-org-get-team-by-name.yml
+++ b/.github/workflows/gh-org-get-team-by-name.yml
@@ -1,0 +1,28 @@
+name: Get a team by name
+
+on:
+  workflow_dispatch:
+    inputs:
+      org:
+        description: 'Org name.'
+        required: true
+        default: 'ws2git'
+      team:
+        description: 'Team name.'
+        required: true
+        default: 'ops'
+
+jobs:
+  get_org_team:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get a team by name
+        env:
+          ORG: "${{ github.event.inputs.org }}"
+          TEAM_SLUG: "${{ github.event.inputs.team }}"
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /orgs/"$ORG"/teams/"$TEAM_SLUG"

--- a/.github/workflows/gh-org-members-invite.yml
+++ b/.github/workflows/gh-org-members-invite.yml
@@ -1,0 +1,41 @@
+name: Members Invitation
+
+on:
+  workflow_dispatch:
+    inputs:
+      org:
+        description: 'Organization.'
+        required: true
+        default: 'ws2git'
+      user:
+        description: 'User to invite.'
+        required: true
+        default: 'user@email.com'
+      team:
+        description: 'Team ID.'
+        required: false
+        default: '1234567'
+
+jobs:
+  invite_member_to_org:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Invite a Member
+        env:
+          ORG: "${{ github.event.inputs.org }}"
+          USER: "${{ github.event.inputs.user }}"
+          TEAM_ID: "${{ github.event.inputs.team }}"
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /orgs/"$ORG"/invitations \
+            --input - <<< '{
+              "email": "'"$USER"'",
+              "role": "direct_member",
+              "team_ids": [
+                  '$TEAM_ID'
+              ]
+            }'


### PR DESCRIPTION
This pull request introduces new GitHub Actions workflows that empower users to manage organizational teams and members directly through their GitHub repositories. These workflows automate key administrative tasks, making it simpler to retrieve team information and invite new members to an organization.

### Implemented Scripts:

* `gh-org-get-team-by-name.yml`: This GitHub Actions workflow allows users to retrieve details for a specific team within an organization. By providing the organization and team names, this script leverages the GitHub API to fetch and display team information, offering a quick way to verify team configurations.

* `gh-org-members-invite.yml`: This workflow automates the process of inviting a new member to an organization. It accepts inputs for the organization, the user's email, and an optional team ID to which the user should be added. It uses the GitHub API to send the invitation, streamlining the onboarding of new team members.