### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gh-repo-list-save.yml
+++ b/.github/workflows/gh-repo-list-save.yml
@@ -1,4 +1,7 @@
 name: List Repositories and Save
+permissions:
+  contents: read
+  actions: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/ws2git/gitnap/security/code-scanning/9](https://github.com/ws2git/gitnap/security/code-scanning/9)

The best way to fix this issue is to add an explicit `permissions` block at the root level of the workflow YAML file, defining the minimum permissions required for successful execution. Since the job only lists repositories and uploads an artifact, it only needs `contents: read` and possibly `actions: read`. No write-level permissions are needed for issues, pull requests, or repository contents. To fix, insert the `permissions:` block directly beneath the workflow name and above the `on:` block in `.github/workflows/gh-repo-list-save.yml`. No extra dependencies or imports are needed, only the `permissions` key in YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
