### PR TITLE
Fix: Description for limit_output parameter

### DIFF
--- a/.github/workflows/gh-repo-list-save.yml
+++ b/.github/workflows/gh-repo-list-save.yml
@@ -11,7 +11,7 @@ on:
         required: true
         default: 'github'
       limit_output:
-        description: 'Github repo owner name.'
+        description: 'Limit output.'
         required: false
         default: '100'
 


### PR DESCRIPTION
Fix parameter in `gh-repo-list-save.yml`